### PR TITLE
feat: Add selective PDF export by class and subject

### DIFF
--- a/index.html
+++ b/index.html
@@ -90,8 +90,18 @@
                         </button>
                         <input type="file" id="load-state-input" class="hidden" accept=".json">
                         <div style="border-top: 1px solid var(--color-gray-200); margin-top: 1.5rem; padding-top: 1.5rem;">
-                             <button id="export-pdf-btn" class="btn btn-dark-gray">
-                                Alle Schüler als PDF speichern
+                            <div class="space-y-3" style="margin-bottom: 1.5rem;">
+                                <div>
+                                    <label for="export-klasse-select" class="form-label text-sm">Klasse für Export auswählen</label>
+                                    <select id="export-klasse-select" class="form-select" style="width: 100%;"></select>
+                                </div>
+                                <div>
+                                    <label for="export-fach-select" class="form-label text-sm">Fach für Export auswählen</label>
+                                    <select id="export-fach-select" class="form-select" style="width: 100%;"></select>
+                                </div>
+                            </div>
+                            <button id="export-pdf-btn" class="btn btn-dark-gray">
+                                Auswahl als PDF speichern
                             </button>
                         </div>
                     </div>

--- a/styles.css
+++ b/styles.css
@@ -150,11 +150,27 @@ h1, h2, h3, h4, h5, h6 {
     border-radius: var(--rounded-lg);
     padding: 0.5rem;
 }
-.form-textarea:focus {
+.form-textarea:focus, .form-select:focus {
     outline: 2px solid transparent;
     outline-offset: 2px;
     border-color: var(--color-primary);
     box-shadow: 0 0 0 2px var(--color-primary);
+}
+
+.form-select {
+    width: 100%;
+    border: 1px solid var(--color-gray-300);
+    border-radius: var(--rounded-lg);
+    padding: 0.5rem;
+    background-color: var(--color-white);
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
+    background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 20 20'%3e%3cpath stroke='%236b7280' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='M6 8l4 4 4-4'/%3e%3c/svg%3e");
+    background-position: right 0.5rem center;
+    background-repeat: no-repeat;
+    background-size: 1.5em 1.5em;
+    padding-right: 2.5rem;
 }
 
 .btn {


### PR DESCRIPTION
This commit introduces the ability for users to select a specific class and subject to export as a PDF, rather than exporting all students at once.

Key changes:
- Added dropdown menus to the UI for selecting a class and subject for export.
- Implemented logic to dynamically populate these dropdowns based on the available data.
- Updated the PDF export function to only include students from the selected class and subject.
- The exported PDF's filename is now dynamically generated to include the selected class and subject.