### PR TITLE
fix: Invert evaluation bar logic

### DIFF
--- a/script.js
+++ b/script.js
@@ -422,7 +422,7 @@ document.addEventListener('DOMContentLoaded', function () {
             const bewertungIndex = aktuelleBewertung[kIndex];
             if (bewertungIndex === null || bewertungIndex >= abstufungen.length) return;
 
-            const prozent = (bewertungIndex + 1) / abstufungen.length * 100;
+            const prozent = (abstufungen.length - bewertungIndex) / abstufungen.length * 100;
             const farbe = farben[bewertungIndex % farben.length];
 
             const barContainer = document.createElement('div');


### PR DESCRIPTION
This commit inverts the logic for the evaluation progress bars in the visual evaluation chart. Previously, "Herausragend" (outstanding) was represented by a short bar, and "Noch nicht erkennbar" (not yet recognizable) was represented by a full bar. This has been corrected so that higher achievement levels correspond to longer bars, as is visually intuitive.