### PR TITLE
feat: Implement drag-and-drop sorting for gradations

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -250,6 +250,13 @@ h1, h2, h3, h4, h5, h6 {
     border-radius: 0.375rem;
     padding: 4px 8px;
     font-size: 0.875rem;
+    cursor: move;
+    transition: opacity 0.2s ease-in-out, background-color 0.2s ease-in-out;
+}
+.tag.dragging {
+    opacity: 0.5;
+    background-color: var(--color-primary);
+    color: var(--color-white);
 }
 .tag button {
     margin-left: 8px;


### PR DESCRIPTION
This commit introduces drag-and-drop functionality to the "Abstufungen" (gradations) list, allowing users to reorder them at any time. The order of gradations is crucial as it directly controls the color-coding in the evaluation grid.

- Modified the `setupTagInput` function in `script.js` to add `draggable="true"` to the tag elements.
- Implemented `dragstart`, `dragover`, `drop`, and `dragend` event listeners to handle the sorting logic.
- The underlying `abstufungen` array is now reordered on a successful drop, and the UI is updated by re-rendering the tags.
- The evaluation grid and chart are also refreshed to reflect the new order.
- Added a `.dragging` CSS class in `styles.css` to provide visual feedback during the drag operation.
- Refactored the drop handler to remove a redundant `if/else` block.